### PR TITLE
Initial RPM packaging & instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+rpm/SRPMS/*
+rpm/RPMS/*
+rpm/SOURCES/*.zip
+rpm/BUILD/*
+rpm/BUILDROOT/*

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -1,0 +1,82 @@
+RPM packaging
+=============
+
+**Beware** The contents of this tree is still under going testing.
+
+The contents of this tree create a self contained RPM file of the
+[Ghost](http://ghost.org) blog software. It is designed to be built
+using mock, though direct rpmbuild calls will work too.
+
+Building the package
+--------------------
+
+To work around wget not recognising the alternative DNS name in the
+ghost.org SSL certificate, add the following to ```$HOME/.wgetrc```. There is an [issue open](https://github.com/TryGhost/Ghost-Config/issues/2) for this. Once fixed this step won't be required.
+```
+check-certificate=off
+```
+
+### Using mock
+
+This is the prefered method of building RPM packages.
+
+* Install CentOS 6.4
+* Install [EPEL](http://fedoraproject.org/wiki/EPEL) access from [RPM](http://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/6/i386/repoview/epel-release.html)
+* Install the build tools
+```sh
+sudo yum install rpmdevtools rpm-build mock yum-utils git
+```
+* Add your user to the mock group
+```
+sudo usermod -a -G mock $( whoami )
+```
+* Checkout this repository
+* To build the latest version run
+```sh
+./build
+```
+To build a specific version append it to the build.sh call, e.g.
+```sh
+./build 0.3.2
+```
+* The packages will be in the ```RPM/``` directory
+
+### Using rpmbuild
+
+To use rpmbuild rather than mock, install EPEL as above. Create a file
+called $HOME/.rpmmacros containing the following and set %_topdir to where-ever
+you have the rpm folder
+
+```
+%_topdir      %(echo $HOME)/Ghost-Config/rpm
+%_smp_mflags  -j3
+%__arch_install_post   /usr/lib/rpm/check-rpaths   /usr/lib/rpm/check-buildroot
+```
+
+cd to your topdir and install build dependencies with the following, replacing 0.3.3 with the version of Ghost you wish to build
+```
+sudo yum-builddep SPECS/ghost.spec
+spectool -g -C SOURCES -d '_ver 0.3.3' SPECS/ghost.spec
+```
+Now build the packages with the following, again replacing 0.3.3 with the version required
+```
+rpmbuild -D '_ver 0.3.3' -ba SPECS/ghost.spec
+```
+
+The built RPM file will be in RPMS/$arch/ where arch is your system's architecture - x86_64, i686 etc.
+
+Installing the package
+----------------------
+
+EPEL is needed, as per the build steps above. Once that's installed run:
+```sh
+sudo yum install ghost-0.3.3-1.el6.x86_64.rpm
+```
+The application gets installed in /opt/ghost.
+Configure ghost to your needs by editing /etc/ghost.conf and then
+run ```sudo service ghost start``` to start up. Once you're happy it's running as you way, run ```sudo chkconfig ghost on``` to start at boot time
+
+Upgrading the package
+---------------------
+
+During package upgrade, if Ghost is running it will be stopped and started, launching the new version of the software.

--- a/rpm/SOURCES/ghost.config.js
+++ b/rpm/SOURCES/ghost.config.js
@@ -1,0 +1,102 @@
+// # Ghost Configuration
+// Setup your Ghost install for various environments
+
+var path = require('path'),
+    config;
+
+config = {
+    // ### Production
+    // When running Ghost in the wild, use the production environment
+    // Configure your URL and mail settings here
+    production: {
+        url: 'http://my-ghost-blog.com',
+        mail: {},
+        database: {
+            client: 'sqlite3',
+            connection: {
+                filename: '/var/lib/ghost/production.db'
+            },
+            debug: false
+        },
+        server: {
+            // Host to be passed to node's `net.Server#listen()`
+            host: '127.0.0.1',
+            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
+            port: '2368'
+        }
+    },
+    //
+    // ### Development **(default)**
+    development: {
+        // The url to use when providing links to the site, E.g. in RSS and email.
+        url: 'http://my-ghost-blog.com',
+
+        // Example mail config
+        // Visit http://docs.ghost.org/mail for instructions
+        // ```
+        //  mail: {
+        //      transport: 'SMTP',
+        //      options: {
+        //          service: 'Mailgun',
+        //          auth: {
+        //              user: '', // mailgun username
+        //              pass: ''  // mailgun password
+        //          }
+        //      }
+        //  },
+        // ```
+
+        database: {
+            client: 'sqlite3',
+            connection: {
+                filename: '/var/lib/ghost/development.db'
+            },
+            debug: false
+        },
+        server: {
+            // Host to be passed to node's `net.Server#listen()`
+            host: '127.0.0.1',
+            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
+            port: '2368'
+        }
+    },
+
+
+    // **Developers only need to edit below here**
+
+    // ### Testing
+    // Used when developing Ghost to run tests and check the health of Ghost
+    // Uses a different port number
+    testing: {
+        url: 'http://127.0.0.1:2369',
+        database: {
+            client: 'sqlite3',
+            connection: {
+                filename: '/var/lib/ghost/test.db'
+            }
+        },
+        server: {
+            host: '127.0.0.1',
+            port: '2369'
+        }
+    },
+
+    // ### Travis
+    // Automated testing run through Github
+    travis: {
+        url: 'http://127.0.0.1:2368',
+        database: {
+            client: 'sqlite3',
+            connection: {
+                filename: '/var/lib/ghost/travis.db'
+            }
+        },
+        server: {
+            host: '127.0.0.1',
+            port: '2368'
+        }
+    }
+};
+
+// Export config
+module.exports = config;

--- a/rpm/SOURCES/ghost.init
+++ b/rpm/SOURCES/ghost.init
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# Ghost - This script takes care of starting and stopping the
+#         ghost blogging application
+#
+# chkconfig:   - 80 20
+# description: Ghost is just a blogging platform
+
+### BEGIN INIT INFO
+# Provides: ghost
+# Required-Start: $local_fs $network 
+# Required-Stop: $local_fs $network
+# Default-Stop: 0 1 6
+# Short-Description: Ghost is just a blogging platform
+# Description: Ghost is an Open Source application which allows you to write
+#              and publish your own blog, giving you the tools to make it easy
+#              and even fun to do. It's simple, elegant, and designed so that
+#              you can spend less time making your blog work and more time
+#              blogging.
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+prog="ghost"
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+[ -z "$NODE_ENV" ] && NODE_ENV="production"
+
+lockfile=/var/lock/subsys/$prog
+pidfile="/var/run/${prog}.pid"
+
+start() {
+    echo -n "Starting $prog: "
+    umask 0007
+    daemonize -a -u ghost \
+      -E NODE_ENV=$NODE_ENV \
+      -o /var/log/ghost/standard.log -e /var/log/ghost/error.log \
+      -l /var/run/ghost.lock -p /var/run/ghost.pid \
+      -c /usr/share/ghost \
+      -- /usr/bin/node /usr/share/ghost/index.js
+    if [ $? -eq 0 ]; then
+      echo_success && echo
+    else
+      echo_failure && echo
+    fi
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start|stop|restart)
+        $1
+        ;;
+    force-reload)
+        restart
+        ;;
+    status)
+        status $prog
+        ;;
+    try-restart|condrestart)
+        if status $prog >/dev/null ; then
+            restart
+        fi
+	;;
+    reload)
+        # If config can be reloaded without restarting, implement it here,
+        # remove the "exit", and add "reload" to the usage message below.
+        # For example:
+        # status $prog >/dev/null || exit 7
+        # killproc $prog -HUP
+        action $"Service ${0##*/} does not support the reload action: " /bin/false
+        exit 3
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart|try-restart|force-reload}"
+        exit 2
+esac

--- a/rpm/SOURCES/ghost.logrotate
+++ b/rpm/SOURCES/ghost.logrotate
@@ -1,0 +1,7 @@
+/var/log/ghost/*.log {
+  copytruncate
+  missingok
+  weekly
+  notifempty
+  nocompress
+}

--- a/rpm/SOURCES/ghost.sysconfig
+++ b/rpm/SOURCES/ghost.sysconfig
@@ -1,0 +1,1 @@
+NODE_ENV="production"

--- a/rpm/SPECS/ghost.spec
+++ b/rpm/SPECS/ghost.spec
@@ -1,0 +1,110 @@
+Name:           ghost
+Version:        %{_ver}
+Release:        3%{?dist}
+Summary:        Ghost is a free, open, simple blogging platform
+
+Group:          Application/Internet 
+License:        MIT
+URL:            http://ghost.org/
+Source0:        http://ghost.org/zip/ghost-%{version}.zip
+Source1:	ghost.init
+Source2:	ghost.logrotate
+Source3:	ghost.sysconfig
+Source4:	ghost.config.js
+
+BuildRequires:   nodejs >= 0.10.0 npm rsync
+Requires:        nodejs >= 0.10.0 daemonize
+Requires(post):  chkconfig
+Requires(preun): chkconfig
+Requires(preun): initscripts
+Requires(postun): initscripts
+
+%global installroot %{_datarootdir}/%{name}
+%global username %{name}
+
+%description
+Ghost is an Open Source application which allows you to write and publish your
+own blog, giving you the tools to make it easy and even fun to do. It's simple,
+elegant, and designed so that you can spend less time making your blog work
+and more time blogging.
+
+%prep
+%setup -c
+
+%build
+npm install --production
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT%{installroot} \
+  $RPM_BUILD_ROOT%{_sharedstatedir}/%{name}/ \
+  $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}/ \
+  $RPM_BUILD_ROOT%{_defaultdocdir}/%{name}/
+cp -r core content node_modules $RPM_BUILD_ROOT%{installroot}/
+install -m 0644 package.json index.js config.example.js $RPM_BUILD_ROOT%{installroot}
+install -m 0640 %{_sourcedir}/ghost.config.js $RPM_BUILD_ROOT%{installroot}/config.js
+install -m 0644 -D *.md LICENSE.txt $RPM_BUILD_ROOT%{_defaultdocdir}/%{name}/
+install -D %{_sourcedir}/ghost.init $RPM_BUILD_ROOT%{_sysconfdir}/init.d/ghost
+install -m 0644 -D %{_sourcedir}/ghost.logrotate \
+  $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/ghost
+install -m 0644 -D %{_sourcedir}/ghost.sysconfig \
+  $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/ghost
+ln -s %{installroot}/config.js $RPM_BUILD_ROOT/%{_sysconfdir}/ghost.conf
+touch $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}/standard.log
+touch $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}/error.log
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%dir %{installroot}
+%{installroot}/index.js
+%{installroot}/package.json
+%{installroot}/config.example.js
+%{installroot}/core
+%{installroot}/node_modules
+%dir %{installroot}/content/
+%attr(0755,%{username},%{username}) %{installroot}/content/*
+%attr(0750,%{username},%{username}) %dir %{_sharedstatedir}/ghost
+%dir %{_defaultdocdir}/%{name}
+%doc %{_defaultdocdir}/%{name}/*
+%{_sysconfdir}/init.d/ghost
+%{_sysconfdir}/logrotate.d/ghost
+%attr(0640,root,%{username}) %config(noreplace) %{installroot}/config.js
+%{_sysconfdir}/ghost.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/ghost
+%attr(0750,%{username},%{username}) %dir %{_localstatedir}/log/ghost
+%attr(0640,%{username},%{username}) %config %ghost %{_localstatedir}/log/ghost/standard.log
+%attr(0640,%{username},%{username}) %config %ghost %{_localstatedir}/log/ghost/error.log
+
+
+%pre
+getent group %{username} >/dev/null || groupadd -r %{username}
+getent passwd %{username} >/dev/null || \
+  useradd -r -g %{username} -d %{_prefix} -s /bin/false \
+  -c "%{name} user" %{username}
+exit 0
+
+%post
+/sbin/chkconfig --add %{name}
+
+%preun
+if [ "$1" -eq "0" ] ; then
+    /sbin/service ghost stop >/dev/null 2>&1
+    /sbin/chkconfig --del %{name}
+fi
+
+%postun
+if [ "$1" -ge "1" ] ; then
+   /sbin/service %{name} condrestart >/dev/null 2>&1 || true
+fi
+
+%changelog
+* Sun Nov 10 2013 Matt Willsher <matt@monki.org.uk>
+- Include logs as ghost entries
+- Remove supervisor dependency
+
+* Fri Nov 08 2013 Matt Willsher <matt@monki.org.uk> 
+- Initial packaging

--- a/rpm/build
+++ b/rpm/build
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [[ $1 == 'clean' ]]
+then
+ [[ -d RPMS ]] && rm -fr RPMS/*
+ [[ -d SRPMS ]] && rm -fr SRPMS/*
+ echo "Cleaned RPMS & SRPMS"
+ exit 0
+fi
+
+dist=$( rpm --showrc | grep ' dist\s' | awk '{ print $3 }' )
+release=$( grep -i Release SPECS/ghost.spec | egrep -o '[0-9]+' )$dist
+
+ver=$1
+
+if [[ $ver == '' ]]
+then 
+  ver=$( curl -s -I https://ghost.org/zip/ghost-latest.zip |
+    grep Location: |
+    egrep -o '([0-9]+\.){2}[0-9]+' )
+fi
+
+echo "Building ghost '$ver' -> "
+
+if [[ ! -f SOURCES/ghost-$ver.zip ]]
+then
+  spectool -g -d "_ver $ver" -C SOURCES SPECS/ghost.spec
+fi
+
+mock --buildsrpm -D "_ver $ver" \
+  --sources SOURCES --resultdir=SRPMS/  \
+  --spec SPECS/ghost.spec &&
+  mock -D "_ver $ver" \
+  --resultdir=RPMS/ \
+  SRPMS/ghost-${ver}-${release}.src.rpm 
+
+


### PR DESCRIPTION
Hi,

This is initial RPM packaging work for Ghost. It's tested on CentOS 6.x, but should be considered beta. Upgrade between releases works smoothly.   The packages is build to take on the work in  TryGhost/Ghost#1364 , TryGhost/Ghost#1100  (/etc/ghost.conf exists as a symlink for now)

I'd be happy to work with the team to set up an official YUM repository for Ghost, with proper package signing, if that would be of use?

Matt
