### PR TITLE
Required email parameters and removed service transport.

### DIFF
--- a/azure/Ghost/config.js
+++ b/azure/Ghost/config.js
@@ -14,7 +14,7 @@ config = {
         // Visit http://docs.ghost.org/mail for instructions
 
         mail: {
-            transport: 'PlaceholderForTransport',
+            transport: 'SMTP',
             options: {
                 service: 'PlaceholderForService',
                 auth: {
@@ -46,7 +46,7 @@ config = {
     production: {
         url: 'PlaceholderForUrl',
         mail: {
-            transport: 'PlaceholderForTransport',
+            transport: 'SMTP',
             options: {
                 service: 'PlaceholderForService',
                 auth: {

--- a/azure/parameters.xml
+++ b/azure/parameters.xml
@@ -8,19 +8,13 @@
   <parameter name="Url" friendlyName="Ghost URL" description="The URL where Ghost will be hosted." defaultValue="http://my-ghost-blog.com" tags="AppURL">
     <parameterEntry type="TextFile" scope="config.js" match="PlaceholderForUrl" />
   </parameter>
-  <parameter name="Transport" friendlyName="Email Transport" description="The email transport that Ghost should use.  (I.e. SMTP)">
-    <parameterEntry type="TextFile" scope="config.js" match="PlaceholderForTransport" />
-  </parameter>
-  <parameter name="ServiceName" friendlyName="Email Service" description="The name of the email service that Ghost should use.  (I.e. Gmail, Mailgun, Sendgrid)">
-    <parameterValidation type="AllowEmpty" />
+  <parameter name="Email Service Name" friendlyName="Email Service" description="The name of the email service that Ghost should use.  (I.e. Gmail, Mailgun, Sendgrid)">
     <parameterEntry type="TextFile" scope="config.js" match="PlaceholderForService" />
   </parameter>
-  <parameter name="ServiceUser" friendlyName="Email Service User" description="The user of the email service.">
-    <parameterValidation type="AllowEmpty" />
+  <parameter name="Email Service User" friendlyName="Email Service User" description="The user of the email service.">
     <parameterEntry type="TextFile" scope="config.js" match="PlaceholderForUser" />
   </parameter>
-  <parameter name="ServicePassword" friendlyName="Email Service Password" description="The password for the user of the email service." tags="New, Password, NoStore">
-    <parameterValidation type="AllowEmpty" />
+  <parameter name="Email Service Password" friendlyName="Email Service Password" description="The password for the user of the email service." tags="New, Password, NoStore">
     <parameterEntry type="TextFile" scope="config.js" match="PlaceholderForPassword" />
   </parameter>
 </parameters>


### PR DESCRIPTION
Initial testing from Microsoft:
- Require email fields (all or none, not some of the fields)
- Better parameter names
- Removed Email Transport - current Azure Gallery configuration only allows for SMTP, so no sense is confusing end user at with unnecessary details at this point.
