### PR TITLE
add sample systemd service file

### DIFF
--- a/systemd/ghost.service
+++ b/systemd/ghost.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=ghost
+After=network.target
+
+[Service]
+Type=simple
+# Edit WorkingDirectory, User and Group as needed
+WorkingDirectory=/path/to/Ghost
+User=http
+Group=http
+ExecStart=/usr/bin/npm start --production
+ExecStop=/usr/bin/npm stop --production
+Restart=always
+SyslogIdentifier=Ghost
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
A sample service file for systemd to start Ghost. 

This is the basic service file that I use for various nodejs based apps. It will restart the process if it fails and send any logging to the standard system logging (can be seen with `journalctl -u ghost`).
