### PR TITLE
Make init script suit multiple Ghosts environment

### DIFF
--- a/init.d/ghost
+++ b/init.d/ghost
@@ -55,11 +55,7 @@ do_start()
     #   2 if daemon could not be started
     start-stop-daemon --start --quiet \
         --chuid $GHOST_USER:$GHOST_GROUP --chdir $GHOST_ROOT --background \
-        --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
-        || return 1
-    start-stop-daemon --start --quiet \
-        --chuid $GHOST_USER:$GHOST_GROUP --chdir $GHOST_ROOT --background \
-        --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS \
+        --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS \
         || return 2
     # Add code here, if necessary, that waits for the process to be ready
     # to handle requests from services started subsequently which depend
@@ -86,9 +82,6 @@ do_stop()
     # that waits for the process to drop all resources that could be
     # needed by services started subsequently.  A last resort is to
     # sleep for some time.
-    start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 \
-        --exec $DAEMON
-    [ "$?" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.
     rm -f $PIDFILE
     return "$RETVAL"
@@ -126,7 +119,7 @@ stop)
         esac
         ;;
 status)
-    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
 #reload|force-reload)
         #
@@ -146,7 +139,6 @@ restart|force-reload)
         do_stop
         case "$?" in
         0|1)
-                do_start
                 do_start
                 case "$?" in
                         0) log_end_msg 0 ;;


### PR DESCRIPTION
The origin script will kill all running node processes (even the non Ghost nodejs app) on the system when user stop the daemon. This fix will be 'more' compatible with the multiple Ghost instances environment.
Also fix some minor bugs.
- No $PIDFILE was created
- Start app twice in the restart section
